### PR TITLE
Add option to write newick/nexus output with node labels

### DIFF
--- a/treemaker/test_treemaker.py
+++ b/treemaker/test_treemaker.py
@@ -215,10 +215,12 @@ class Test_TreeMakerIO(unittest.TestCase):
     
     def test_write_newick(self):
         assert self.t.write(mode="newick") == "((A,(AB1,AB2)),C);"
-
+        assert self.t.write(mode="newick", nodes=['a','b']) == "((A,(AB1,AB2)b)a,C);"
+    
     def test_write_nexus(self):
         assert self.t.write(mode="nexus").startswith("#NEXUS")
         assert "((A,(AB1,AB2)),C)" in self.t.write(mode="nexus")
+        assert "((A,(AB1,AB2)),(C)c)" in self.t.write(mode="nexus", nodes=['c'])
     
     def test_write_nexus_error_on_bad_method(self):
         with self.assertRaises(ValueError):

--- a/treemaker/test_treemaker.py
+++ b/treemaker/test_treemaker.py
@@ -215,12 +215,12 @@ class Test_TreeMakerIO(unittest.TestCase):
     
     def test_write_newick(self):
         assert self.t.write(mode="newick") == "((A,(AB1,AB2)),C);"
-        assert self.t.write(mode="newick", nodes=['a','b']) == "((A,(AB1,AB2)b)a,C);"
+        assert self.t.write(mode="newick", show_nodes=['a', 'b']) == "((A,(AB1,AB2)b)a,C);"
     
     def test_write_nexus(self):
         assert self.t.write(mode="nexus").startswith("#NEXUS")
         assert "((A,(AB1,AB2)),C)" in self.t.write(mode="nexus")
-        assert "((A,(AB1,AB2)),(C)c)" in self.t.write(mode="nexus", nodes=['c'])
+        assert "((A,(AB1,AB2)),(C)c)" in self.t.write(mode="nexus", show_nodes=['c'])
     
     def test_write_nexus_error_on_bad_method(self):
         with self.assertRaises(ValueError):

--- a/treemaker/treemaker.py
+++ b/treemaker/treemaker.py
@@ -275,7 +275,7 @@ class TreeMaker(object):
                 self.add(*[_.strip() for _ in IS_WHITESPACE.split(line, 1)])
         return self.tree
     
-    def write(self, mode="newick", nodes=[]):
+    def write(self, mode="newick", show_nodes=[]):
         """
         Writes the output form of the tree.
         
@@ -283,7 +283,7 @@ class TreeMaker(object):
             mode (str): An output mode. One of: 
                 * "nexus" = a nexus file is generated
                 * "newick" = a newick file (bare tree) is generated
-            nodes (list): Nodes to be labeled in the output.
+            show_nodes (list): Nodes to be labeled in the output.
         
         Returns:
             str: a string containing the formatted content.
@@ -303,7 +303,7 @@ class TreeMaker(object):
                 "Unknown output mode. Please use 'nexus' or 'newick'"
             )
         
-    def write_to_file(self, filename, mode="nexus", nodes=[]):
+    def write_to_file(self, filename, mode="nexus", show_nodes=[]):
         """
         Writes the tree to `filename`.
         
@@ -312,7 +312,7 @@ class TreeMaker(object):
             mode (str): An output mode. One of:
                 * "nexus" = a nexus file is generated
                 * "newick" = a newick file (bare tree) is generated
-            nodes (list): Nodes to be labeled in the output.
+            show_nodes (list): Nodes to be labeled in the output.
         
         Returns:
             None
@@ -325,9 +325,9 @@ class TreeMaker(object):
             raise IOError("File %s already exists" % filename)
         
         if mode == 'nexus':
-            content = self.write(mode="nexus", nodes=nodes)
+            content = self.write(mode="nexus", show_nodes=show_nodes)
         elif mode == 'newick':
-            content = self.write(mode="newick", nodes=nodes)
+            content = self.write(mode="newick", show_nodes=show_nodes)
         else:
             raise ValueError(
                 "Unknown output mode. Please use 'nexus' or 'newick'"


### PR DESCRIPTION
This PR adds an option to include node labels in the newick/nexus output.

I am not sure if it should be shared in public―it might be a bit niche option―and am also not sure if this is the optimal implementation to achieve it.
Feel free to close this PR if it is not proper enough to be merged.